### PR TITLE
Added rpc for the deletion flow

### DIFF
--- a/common.proto
+++ b/common.proto
@@ -49,6 +49,11 @@ message CertificationDetails{
     string certificationAgency = 4;
 }
 
+message DeletionInfo {
+    int64 deletionTime = 1;
+    string reason = 2;
+}
+
 message UserProfileProto {
     string loginId = 1;
     string name = 2;
@@ -66,6 +71,7 @@ message UserProfileProto {
     repeated string attributes = 15;
     LandSizeInAcres landSizeInAcres = 16;
     Location location = 17;
+    DeletionInfo deletionInfo = 18;
 }
 
 message StatusResponse {

--- a/login.proto
+++ b/login.proto
@@ -11,6 +11,7 @@ option go_package = "github.com/Kotlang/authGo/generated";
 package login;
 
 service Login {
+    // Login with email or phone sends status response with message "Marked for deletion" if user is marked for deletion
     rpc Login(LoginRequest) returns (StatusResponse) {}
     rpc verify(VerifyRequest) returns (AuthResponse) {}
 }

--- a/profile.proto
+++ b/profile.proto
@@ -22,6 +22,10 @@ service Profile {
     rpc getProfileByPhoneOrEmail(GetProfileByPhoneOrEmailRequest) returns (UserProfileProto) {}
 	rpc isUserAdmin(IdRequest) returns (IsUserAdminResponse) {}
     rpc FetchProfiles(FetchProfilesRequest) returns (ProfileListResponse) {}
+    rpc requestProfileDeletion(ProfileDeletionRequest) returns (StatusResponse){}
+    rpc deleteProfile(IdRequest) returns (StatusResponse){}
+    rpc getPendingProfileDeletionRequests(GetProfileDeletionRequest) returns (ProfileListResponse){}
+    rpc unDeleteProfile(IdRequest) returns (StatusResponse){}
 }
 
 //all are optional. If any of the field is not set, old value will be retained.
@@ -104,4 +108,13 @@ message GetProfileByPhoneOrEmailRequest {
 
 message IsUserAdminResponse {
 	bool isAdmin = 1;
+}
+
+message GetProfileDeletionRequest {
+    int32 pageSize = 1;
+    int32 pageNumber = 2;
+}
+
+message ProfileDeletionRequest {
+    string reason = 1;
 }

--- a/profile.proto
+++ b/profile.proto
@@ -25,7 +25,7 @@ service Profile {
     rpc requestProfileDeletion(ProfileDeletionRequest) returns (StatusResponse){}
     rpc deleteProfile(IdRequest) returns (StatusResponse){}
     rpc getPendingProfileDeletionRequests(GetProfileDeletionRequest) returns (ProfileListResponse){}
-    rpc unDeleteProfile(IdRequest) returns (StatusResponse){}
+    rpc cancelProfileDeletionRequest(IdRequest) returns (StatusResponse){}
 }
 
 //all are optional. If any of the field is not set, old value will be retained.


### PR DESCRIPTION
Added following rpc: 

> rpc requestProfileDeletion(ProfileDeletionRequest) returns (StatusResponse){}
    rpc deleteProfile(IdRequest) returns (StatusResponse){}
    rpc getPendingProfileDeletionRequests(GetProfileDeletionRequest) returns (ProfileListResponse){}
    rpc unDeleteProfile(IdRequest) returns (StatusResponse){}